### PR TITLE
feat: add auto-collapse option

### DIFF
--- a/src/multiplex/box.py
+++ b/src/multiplex/box.py
@@ -8,17 +8,17 @@ logger = logging.getLogger("multiplex.box")
 
 
 class BoxHolder:
-    def __init__(self, index, iterator, box_height, auto_collapse, viewer):
+    def __init__(self, index, iterator, box_height, viewer):
         self.id = id(self)
         self.index = index
         self.iterator = iterator
         self.buffer = Buffer(buffer_lines=viewer.buffer_lines)
-        self.state = BoxState(box_height, auto_collapse)
+        self.state = BoxState(box_height)
         self.box = TextBox(viewer, self)
 
 
 class BoxState:
-    def __init__(self, box_height, auto_collapse):
+    def __init__(self, box_height):
         self.wrap = True
         self.auto_scroll = True
         self.input_mode = False
@@ -30,7 +30,6 @@ class BoxState:
         self.text = None
         self.changed_height = box_height is not None
         self.box_height = box_height
-        self.auto_collapse = auto_collapse
 
 
 class TextBox:
@@ -177,8 +176,6 @@ class TextBox:
         return True
 
     def exit_input_mode(self):
-        if self.state.auto_collapse and self.holder.iterator.metadata["exit_code"] == 0:
-            self.toggle_collapse(value=True)
         self.state.input_mode = False
         ansi.hide_cursor()
         return True

--- a/src/multiplex/box.py
+++ b/src/multiplex/box.py
@@ -177,7 +177,7 @@ class TextBox:
         return True
 
     def exit_input_mode(self):
-        if self.state.auto_collapse:
+        if self.state.auto_collapse and self.holder.iterator.metadata["exit_code"] == 0:
             self.toggle_collapse(value=True)
         self.state.input_mode = False
         ansi.hide_cursor()

--- a/src/multiplex/box.py
+++ b/src/multiplex/box.py
@@ -8,17 +8,17 @@ logger = logging.getLogger("multiplex.box")
 
 
 class BoxHolder:
-    def __init__(self, index, iterator, box_height, viewer):
+    def __init__(self, index, iterator, box_height, auto_collapse, viewer):
         self.id = id(self)
         self.index = index
         self.iterator = iterator
         self.buffer = Buffer(buffer_lines=viewer.buffer_lines)
-        self.state = BoxState(box_height)
+        self.state = BoxState(box_height, auto_collapse)
         self.box = TextBox(viewer, self)
 
 
 class BoxState:
-    def __init__(self, box_height):
+    def __init__(self, box_height, auto_collapse):
         self.wrap = True
         self.auto_scroll = True
         self.input_mode = False
@@ -30,6 +30,7 @@ class BoxState:
         self.text = None
         self.changed_height = box_height is not None
         self.box_height = box_height
+        self.auto_collapse = auto_collapse
 
 
 class TextBox:
@@ -176,6 +177,8 @@ class TextBox:
         return True
 
     def exit_input_mode(self):
+        if self.state.auto_collapse:
+            self.toggle_collapse(value=True)
         self.state.input_mode = False
         ansi.hide_cursor()
         return True

--- a/src/multiplex/main.py
+++ b/src/multiplex/main.py
@@ -99,7 +99,7 @@ def validate(box_height, process, socket_path, title, wait, load):
     "--auto-collapse/--no-auto-collapse",
     type=bool,
     envvar="MULTIPLEX_AUTO_COLLAPSE",
-    help="Collapse buffers automatically upon successful completion"
+    help="Collapse buffers automatically upon successful completion",
 )
 @click.option(
     "-o",
@@ -122,7 +122,9 @@ def validate(box_height, process, socket_path, title, wait, load):
 @click.help_option("-h", "--help")
 @click.version_option(None, "--version")
 @click.option("-v", "--verbose", is_flag=True)
-def main(process, title, verbose, box_height, auto_collapse, output_path, wait, load, socket_path, buffer_lines, server):
+def main(
+    process, title, verbose, box_height, auto_collapse, output_path, wait, load, socket_path, buffer_lines, server
+):
     validate(
         box_height=box_height,
         process=process,

--- a/src/multiplex/main.py
+++ b/src/multiplex/main.py
@@ -37,10 +37,11 @@ async def ipc_mode(socket_path, process, title, box_height, wait, load):
         await client.batch(actions)
 
 
-def direct_mode(process, title, verbose, box_height, output_path, load, socket_path, buffer_lines):
+def direct_mode(process, title, verbose, box_height, auto_collapse, output_path, load, socket_path, buffer_lines):
     multiplex = Multiplex(
         verbose=verbose,
         box_height=box_height[0],
+        auto_collapse=auto_collapse,
         output_path=output_path,
         socket_path=socket_path,
         buffer_lines=buffer_lines,
@@ -94,6 +95,13 @@ def validate(box_height, process, socket_path, title, wait, load):
     help="By default, buffer length is unbounded. Use this to have a maximum number of lines for each " "buffer.",
 )
 @click.option(
+    "-a/-A",
+    "--auto-collapse/--no-auto-collapse",
+    type=bool,
+    envvar="MULTIPLEX_AUTO_COLLAPSE",
+    help="Collapse buffers automatically upon successful completion"
+)
+@click.option(
     "-o",
     "--output-path",
     help="Root directory to use when saving output",
@@ -114,7 +122,7 @@ def validate(box_height, process, socket_path, title, wait, load):
 @click.help_option("-h", "--help")
 @click.version_option(None, "--version")
 @click.option("-v", "--verbose", is_flag=True)
-def main(process, title, verbose, box_height, output_path, wait, load, socket_path, buffer_lines, server):
+def main(process, title, verbose, box_height, auto_collapse, output_path, wait, load, socket_path, buffer_lines, server):
     validate(
         box_height=box_height,
         process=process,
@@ -148,6 +156,7 @@ def main(process, title, verbose, box_height, output_path, wait, load, socket_pa
             title=title,
             verbose=verbose,
             box_height=box_height,
+            auto_collapse=auto_collapse,
             output_path=output_path,
             load=load,
             socket_path=socket_path,

--- a/src/multiplex/multiplex.py
+++ b/src/multiplex/multiplex.py
@@ -8,7 +8,9 @@ from multiplex.ipc import Server
 
 
 class Multiplex:
-    def __init__(self, verbose=False, box_height=None, auto_collapse=False, output_path=None, socket_path=None, buffer_lines=None):
+    def __init__(
+        self, verbose=False, box_height=None, auto_collapse=False, output_path=None, socket_path=None, buffer_lines=None
+    ):
         self.descriptors: List[Descriptor] = []
         self.verbose = verbose
         self.box_height = box_height

--- a/src/multiplex/multiplex.py
+++ b/src/multiplex/multiplex.py
@@ -8,10 +8,11 @@ from multiplex.ipc import Server
 
 
 class Multiplex:
-    def __init__(self, verbose=False, box_height=None, output_path=None, socket_path=None, buffer_lines=None):
+    def __init__(self, verbose=False, box_height=None, auto_collapse=False, output_path=None, socket_path=None, buffer_lines=None):
         self.descriptors: List[Descriptor] = []
         self.verbose = verbose
         self.box_height = box_height
+        self.auto_collapse = auto_collapse
         self.buffer_lines = buffer_lines
         self.output_path = output_path or os.getcwd()
         self.server = Server(socket_path)
@@ -31,6 +32,7 @@ class Multiplex:
             descriptors=self.descriptors,
             verbose=self.verbose,
             box_height=self.box_height,
+            auto_collapse=self.auto_collapse,
             socket_path=self.server.socket_path,
             output_path=self.output_path,
             buffer_lines=self.buffer_lines,

--- a/src/multiplex/viewer.py
+++ b/src/multiplex/viewer.py
@@ -240,9 +240,7 @@ class Viewer:
             },
         )
         box_height = descriptor.box_height or self.box_height
-        holder = BoxHolder(
-            index, iterator=iterator, box_height=box_height, viewer=self
-        )
+        holder = BoxHolder(index, iterator=iterator, box_height=box_height, viewer=self)
         state = holder.state
         if descriptor.wrap is not None:
             state.wrap = descriptor.wrap

--- a/src/multiplex/viewer.py
+++ b/src/multiplex/viewer.py
@@ -67,7 +67,7 @@ class DescriptorQueueItem:
 
 
 class Viewer:
-    def __init__(self, descriptors, box_height, verbose, socket_path, output_path, buffer_lines):
+    def __init__(self, descriptors, box_height, auto_collapse, verbose, socket_path, output_path, buffer_lines):
         self.holders = []
         self.stream_id_to_holder = {}
         self.holder_to_stream_id = {}
@@ -78,6 +78,7 @@ class Viewer:
         self.events = ViewerEvents()
         self.export = Export(self)
         self.box_height = box_height
+        self.auto_collapse = auto_collapse
         self.buffer_lines = buffer_lines
         self.verbose = verbose
         self.socket_path = socket_path
@@ -239,7 +240,7 @@ class Viewer:
             },
         )
         box_height = descriptor.box_height or self.box_height
-        holder = BoxHolder(index, iterator=iterator, box_height=box_height, viewer=self)
+        holder = BoxHolder(index, iterator=iterator, box_height=box_height, auto_collapse=self.auto_collapse, viewer=self)
         state = holder.state
         if descriptor.wrap is not None:
             state.wrap = descriptor.wrap

--- a/src/multiplex/viewer.py
+++ b/src/multiplex/viewer.py
@@ -241,7 +241,7 @@ class Viewer:
         )
         box_height = descriptor.box_height or self.box_height
         holder = BoxHolder(
-            index, iterator=iterator, box_height=box_height, auto_collapse=self.auto_collapse, viewer=self
+            index, iterator=iterator, box_height=box_height, viewer=self
         )
         state = holder.state
         if descriptor.wrap is not None:
@@ -366,6 +366,8 @@ class Viewer:
                 data(holder)
             elif data is STREAM_DONE:
                 holder.state.stream_done = True
+                if self.auto_collapse and not holder.iterator.metadata.get("exit_code"):
+                    holder.box.toggle_collapse(value=True)
                 holder.box.exit_input_mode()
             else:
                 holder.buffer.write(data)

--- a/src/multiplex/viewer.py
+++ b/src/multiplex/viewer.py
@@ -240,7 +240,9 @@ class Viewer:
             },
         )
         box_height = descriptor.box_height or self.box_height
-        holder = BoxHolder(index, iterator=iterator, box_height=box_height, auto_collapse=self.auto_collapse, viewer=self)
+        holder = BoxHolder(
+            index, iterator=iterator, box_height=box_height, auto_collapse=self.auto_collapse, viewer=self
+        )
         state = holder.state
         if descriptor.wrap is not None:
             state.wrap = descriptor.wrap


### PR DESCRIPTION
I was experimenting with multiplex for docker-compose logs and I often have some long running services and some short running services. When a service is done, I wanted the buffer to auto collapse, so I can forget about it. This adds the `-a/-A` option, along with the `MULTIPLEX_AUTO_COLLAPSE` env variable to do exactly this.